### PR TITLE
DBのカラムにコメントを追加(cherry-pick後)

### DIFF
--- a/database/migrations/2024_06_06_054544_add_comment_to_column.php
+++ b/database/migrations/2024_06_06_054544_add_comment_to_column.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //各カラムにコメントを追加
+            $table->string('name')->comment('僧名')->change();
+            $table->string('email')->comment('メールアドレス')->change();
+            $table->string('password')->comment('パスワード')->change();
+            $table->string('jiin_name')->comment('寺院名')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //各カラムのコメントを削除
+            $table->string('name')->comment(null)->change();
+            $table->string('email')->comment(null)->change();
+            $table->string('password')->comment(null)->change();
+            $table->string('jiin_name')->comment(null)->change();
+        });
+    }
+};


### PR DESCRIPTION
# 概要
- usersテーブルのカラムにコメントを追加
- #8のPRに余分なコミットが混ざっていたのを修正したのがこちらです
## 関連issue
#2 
# やったこと
- usersテーブルのname, email, password, jiin_nameのカラムにコメントを追加
# レビューで特に見てほしいところ
- コメントの過不足がないか
- downに書くロールバック時の処理
- cherry-pickがうまくいっているか
# その他
- マイグレーション必要