### PR TITLE
ユーザー登録時にjiin_nameが空欄の場合、空文字ではなくnullとして登録するように修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -39,7 +39,7 @@ class RegisteredUserController extends Controller
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
-            'jiin_name' => $request->jiin_name ?? '',
+            'jiin_name' => $request->jiin_name,
             'password' => Hash::make($request->password),
         ]);
 

--- a/database/migrations/2024_06_15_104727_change_jiin_name_to_nullable.php
+++ b/database/migrations/2024_06_15_104727_change_jiin_name_to_nullable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //jiin_nameをnullableに変更
+            $table->string('jiin_name')->nullable(true)->comment('寺院名')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //jiin_nameはnullを不可にする
+            $table->string('jiin_name')->nullable(false)->comment('寺院名')->change();
+        });
+    }
+};


### PR DESCRIPTION
# 概要
-  ユーザー登録時に寺院名が空欄だった場合、空文字に変える処理をやめ、nullとしてDB登録するように変更
## 関連issue
- #11 

# やったこと
- jiin_nameをnullableにするマイグレーションファイルを作成
- jiin_nameがLaravelによってnullにされた場合、コントローラで空文字に変更していたが、その処理を削除

# レビューで特に見てほしいところ
- 作業中にブランチ入れ替えてたらごちゃごちゃしちゃったので、変なことになってないか
- マイグレーションファイルの中身

#  その他
- マイグレーション必要