### PR TITLE
プロフィール画面にjiin_nameの編集機能を追加

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -31,10 +31,6 @@ class ProfileController extends Controller
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;
         }
-        
-        if ($request->user()->jiin_name === null) {
-            $request->user()->jiin_name = '';
-        }
 
         $request->user()->save();
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -31,6 +31,10 @@ class ProfileController extends Controller
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;
         }
+        
+        if ($request->user()->jiin_name === null) {
+            $request->user()->jiin_name = '';
+        }
 
         $request->user()->save();
 

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -18,6 +18,7 @@ class ProfileUpdateRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'jiin_name' => ['nullable', 'string', 'max:255']
         ];
     }
 }

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -47,6 +47,12 @@
             @endif
         </div>
 
+        <div>
+        <x-input-label for="jiin_name" value="寺院名" />
+            <x-text-input id="jiin_name" name="jiin_name" type="text" class="mt-1 block w-full" :value="old('jiin_name', $user->jiin_name)" />
+            <x-input-error class="mt-2" :messages="$errors->get('jiin_name')" />
+        </div>
+
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 


### PR DESCRIPTION
# 概要
- プロフィール画面にjiin_nameの編集機能を追加
- 空欄で送信された場合は、Laravelの標準に従ってnullとして登録
## 関連issue
- #4 

# やったこと
- jiin_name編集画面を作成
- ```ProfileUpdateRequest.php```にjiin_nameのバリデーションルールを追加

# レビューで特に見てほしいところ
- 作業中にブランチ入れ替えてたらごちゃごちゃしちゃったので、変なことになってないか