### PR TITLE
檀家さん登録画面&一覧画面

### DIFF
--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Danka;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rules;
+use Illuminate\View\View;
+
+class DankaController extends Controller
+{
+    //檀家一覧
+    public function index()
+    {
+        $dankas = Danka::all()->sortByDesc('created_at');
+        return view('dankas.index', ['dankas' => $dankas]);
+    }
+
+    //檀家登録画面の表示
+    public function create(): View
+    {
+        return view('dankas.register');
+    }
+
+    //檀家登録
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'family_head_last_name' => ['required', 'string', 'max:255'],
+            'family_head_first_name' => ['required', 'string', 'max:255'],
+            'family_head_last_name_kana' => ['required', 'string', 'max:255'],
+            'family_head_first_name_kana' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'confirmed', 'string', 'lowercase', 'email', 'max:255', 'unique:'.Danka::class],
+            'postcode' => ['nullable', 'string', 'max:255'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'phone_number' => ['nullable', 'string', 'max:255'],
+            'note' => ['nullable', 'string'],
+        ]);
+
+        //ここで、emailとphone_numberが両方nullになっていないか確認する。
+        //両方nullの場合は、どちらかは入れてもらうようメッセージを出す
+
+        if (Auth::check()) {
+            $bouzu_id = Auth::id();
+        } else {
+            return redirect()->route('login')->withErrors(['login' => '登録するにはログインが必要です']);
+        }
+
+        $danka = Danka::create([
+            'family_head_last_name' => $request->family_head_last_name,
+            'family_head_first_name' => $request->family_head_first_name,
+            'family_head_last_name_kana' => $request->family_head_last_name_kana,
+            'family_head_first_name_kana' => $request->family_head_first_name_kana,
+            'email' => $request->email,
+            'postcode' => $request->postcode,
+            'address' => $request->address,
+            'phone_number' => $request->phone_number,
+            'note' => $request->note,
+            'bouzu_id' => $bouzu_id,
+        ]);
+
+        return redirect(route('dankas.index', absolute: false));
+    }
+}

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -15,7 +15,8 @@ class DankaController extends Controller
     //檀家一覧
     public function index()
     {
-        $dankas = Danka::all()->sortByDesc('created_at');
+        $bouzu_id = Auth::id();
+        $dankas = Danka::where('bouzu_id', $bouzu_id)->get()->sortByDesc('created_at');
         return view('dankas.index', ['dankas' => $dankas]);
     }
 

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -44,12 +44,6 @@ class DankaController extends Controller
         //ここで、emailとphone_numberが両方nullになっていないか確認する。
         //両方nullの場合は、どちらかは入れてもらうようメッセージを出す
 
-        if (Auth::check()) {
-            $bouzu_id = Auth::id();
-        } else {
-            return redirect()->route('login')->withErrors(['login' => '登録するにはログインが必要です']);
-        }
-
         $danka = Danka::create([
             'family_head_last_name' => $request->family_head_last_name,
             'family_head_first_name' => $request->family_head_first_name,

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Danka extends Model
+{
+    use HasFactory;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'bouzu_id');
+    }
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'family_head_last_name',
+        'family_head_first_name',
+        'family_head_last_name_kana',
+        'family_head_first_name_kana',
+        'email',
+        'postcode',
+        'address',
+        'phone_number',
+        'note',
+        'bouzu_id',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,12 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
+    //Dankaモデルとのリレーション
+    public function dankas(): HasMany
+    {
+        return $this->hasMany(Danka::class, 'bouzu_id');
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/database/migrations/2024_06_22_071339_create_dankas_table.php
+++ b/database/migrations/2024_06_22_071339_create_dankas_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('dankas', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('family_head_last_name')->comment('代表者 姓');
+            $table->string('family_head_first_name')->comment('代表者 名');
+            $table->string('family_head_last_name_kana')->comment('代表者 せい');
+            $table->string('family_head_first_name_kana')->comment('代表者 めい');
+            $table->string('email')->nullable()->unique()->comment('連絡用メールアドレス');
+            $table->string('postcode')->comment('郵便番号');
+            $table->string('address')->comment('住所');
+            $table->string('phone_number')->nullable()->comment('電話番号');
+            $table->text('note')->nullable()->comment('備考');
+            $table->unsignedBigInteger('bouzu_id')->comment('登録したお坊さんuserのid');
+            $table->foreign('bouzu_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dankas');
+    }
+};

--- a/database/migrations/2024_06_23_010042_change_2column_to_nullable.php
+++ b/database/migrations/2024_06_23_010042_change_2column_to_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dankas', function (Blueprint $table) {
+            //郵便番号と住所をnullableに
+            $table->string('postcode')->nullable()->comment('郵便番号')->change();
+            $table->string('address')->nullable()->comment('住所')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dankas', function (Blueprint $table) {
+            //郵便番号と住所のnullを不可に
+            $table->string('postcode')->nullable(false)->comment('郵便番号')->change();
+            $table->string('address')->nullable(false)->comment('住所')->change();
+        });
+    }
+};

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -22,7 +22,7 @@
                             <th>{{ $danka->family_head_last_name}}{{$danka->family_head_first_name }}</th>
                             <th>{{ $danka->email }}</th>
                             <th>{{ $danka->phone_number }}</th>
-                            <th>{{$danka->postcode}}{{$danka->address}}</th>
+                            <th>{{ $danka->postcode }}{{ $danka->address }}</th>
                             <th>{{ $danka->note }}</th>
                         </tr>
                         @endforeach

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -1,0 +1,34 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            檀家一覧
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <table border="1">
+                        <tr>
+                            <th>氏名</th>
+                            <th>メールアドレス</th>
+                            <th>電話番号</th>
+                            <th>住所</th>
+                            <th>備考</th>
+                        </tr>
+                        @foreach ($dankas as $danka)
+                        <tr>
+                            <th>{{ $danka->family_head_last_name}}{{$danka->family_head_first_name }}</th>
+                            <th>{{ $danka->email }}</th>
+                            <th>{{ $danka->phone_number }}</th>
+                            <th>{{$danka->postcode}}{{$danka->address}}</th>
+                            <th>{{ $danka->note }}</th>
+                        </tr>
+                        @endforeach
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/dankas/register.blade.php
+++ b/resources/views/dankas/register.blade.php
@@ -1,0 +1,85 @@
+<x-guest-layout>
+    <form method="POST" action="{{ route('dankas.register') }}">
+        @csrf
+
+        <!-- family_head_last_name -->
+        <div>
+            <x-input-label for="family_head_last_name" value="代表者 姓" />
+            <x-text-input id="family_head_last_name" class="block mt-1 w-full" type="text" name="family_head_last_name" :value="old('family_head_last_name')" required autofocus />
+            <x-input-error :messages="$errors->get('family_head_last_name')" class="mt-2" />
+        </div>
+
+        <!-- family_head_first_name -->
+        <div class="mt-4">
+            <x-input-label for="family_head_first_name" value="代表者 名" />
+            <x-text-input id="family_head_first_name" class="block mt-1 w-full" type="text" name="family_head_first_name" :value="old('family_head_first_name')" required />
+            <x-input-error :messages="$errors->get('family_head_first_name')" class="mt-2" />
+        </div>
+
+        <!-- family_head_last_name_kana -->
+        <div class="mt-4">
+            <x-input-label for="family_head_last_name_kana" value="代表者 せい" />
+            <x-text-input id="family_head_last_name_kana" class="block mt-1 w-full" type="text" name="family_head_last_name_kana" :value="old('family_head_last_name_kana')" required />
+            <x-input-error :messages="$errors->get('family_head_last_name_kana')" class="mt-2" />
+        </div>
+
+        <!-- family_head_first_name_kana -->
+        <div class="mt-4">
+            <x-input-label for="family_head_first_name_kana" value="代表者 めい" />
+            <x-text-input id="family_head_first_name_kana" class="block mt-1 w-full" type="text" name="family_head_first_name_kana" :value="old('family_head_first_name_kana')" required />
+            <x-input-error :messages="$errors->get('family_head_first_name_kana')" class="mt-2" />
+        </div>
+
+        <!-- email -->
+        <div class="mt-4">
+            <x-input-label for="email" value="連絡用メールアドレス" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')"/>
+            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        </div>        
+
+        <!-- email_confirmation -->
+        <div class="mt-4">
+            <x-input-label for="email_confirmation" value="連絡用メールアドレス(確認用)" />
+
+            <x-text-input id="email_confirmation" class="block mt-1 w-full"
+                            type="email"
+                            name="email_confirmation" 
+                            :value="old('email_confirmation')"/>
+
+            <x-input-error :messages="$errors->get('email_confirmation')" class="mt-2" />
+        </div>
+
+        <!-- postcode -->
+        <div class="mt-4">
+            <x-input-label for="postcode" value="郵便番号" />
+            <x-text-input id="postcode" class="block mt-1 w-full" type="tel" name="postcode" :value="old('postcode')" />
+            <x-input-error :messages="$errors->get('postcode')" class="mt-2" />
+        </div>  
+
+        <!-- address -->
+        <div class="mt-4">
+            <x-input-label for="address" value="住所" />
+            <x-text-input id="address" class="block mt-1 w-full" type="text" name="address" :value="old('address')" />
+            <x-input-error :messages="$errors->get('address')" class="mt-2" />
+        </div>  
+
+        <!-- phone_number -->
+        <div class="mt-4">
+            <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
+            <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number')" />
+            <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
+        </div>  
+        
+        <!-- note -->
+        <div>       
+        <x-input-label for="note" value="備考" />
+            <textarea id="note" name="note" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500" >{{ old('note') }}</textarea>
+        </div> 
+
+        <div class="flex items-center justify-end mt-4">
+            <x-primary-button class="ms-4">
+                登録
+            </x-primary-button>
+        </div>
+    </form>
+</x-guest-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -38,6 +38,14 @@
                             プロフィール
                         </x-dropdown-link>
 
+                        <x-dropdown-link :href="route('dankas.index')">
+                            檀家一覧
+                        </x-dropdown-link>
+
+                        <x-dropdown-link :href="route('dankas.register')">
+                            檀家登録
+                        </x-dropdown-link>
+
                         <!-- Authentication -->
                         <form method="POST" action="{{ route('logout') }}">
                             @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\DankaController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +16,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::get('/dankas/index', [DankaController::class, 'index'])->name('dankas.index');
+    Route::get('/dankas/register', [DankaController::class, 'create'])->name('dankas.register');
+    Route::post('/dankas/register', [DankaController::class, 'store']);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
# 概要
- 檀家さん登録画面と一覧画面を作成。
## 関連issue
- #14 
  - #10 の一部

# やったこと
- dankasテーブルの作成
- Dankaモデルの作成、リレーションの設定、fillable
- dankaコントローラの作成。index、create、storeアクションの実装
- 登録画面(register)と一覧画面(index)のビュー

# レビューで特に見てほしいところ
- 全体的に
- フォームの項目が多かったので、ビューを中心にどこかに不備がありそう。

# その他
- マイグレーション必要