### PR TITLE
檀家更新時と削除時に、ログイン中のユーザーに権限があるか確認する

### DIFF
--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -74,13 +74,17 @@ class DankaController extends Controller
     public function update(DankaUpdateRequest $request): RedirectResponse
     {
 
-        $danka_id = $request->id;
-        $danka = Danka::find($danka_id);
-        $danka->fill($request->validated());
-        //TODO: ここで、emailとphone_numberどっちかはあるように確認
-        $danka->save();
-
-        return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
+        $dankaId = $request->id;
+        $danka = Danka::find($dankaId);
+        $bouzuId = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzuId)) {
+            return Redirect::route('welcome')->with('status', 'erroUnauthorized');
+        } else {
+            $danka->fill($request->validated());
+            //TODO: ここで、emailとphone_numberどっちかはあるように確認
+            $danka->save();
+            return Redirect::route('dankas.edit', ['id' => $dankaId])->with('status', 'danka-updated');
+        }
     }
 
     public function destroy(Request $request): RedirectResponse

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -68,7 +68,12 @@ class DankaController extends Controller
     public function edit($id): View
     {
         $danka = Danka::find($id);
-        return view('dankas.edit', ['danka' => $danka]);
+        $bouzuId = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzuId)) {
+            return view('welcome')->with('status', 'erroUnauthorized');
+        } else {
+            return view('dankas.edit', ['danka' => $danka]);
+        }
     }
 
     public function update(DankaUpdateRequest $request): RedirectResponse
@@ -95,8 +100,12 @@ class DankaController extends Controller
 
         $id = $request->id;
         $danka = Danka::find($id);
-        $danka->delete();
-
-        return Redirect::to(route('dankas.index'));
+        $bouzuId = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzuId)) {
+            return Redirect::route('welcome')->with('status', 'erroUnauthorized');
+        } else {
+            $danka->delete();
+            return Redirect::to(route('dankas.index'));
+        }
     }
 }

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -65,12 +65,12 @@ class DankaController extends Controller
         return redirect(route('dankas.index', absolute: false));
     }
 
-    public function edit($id): View
+    public function edit($id): View | RedirectResponse
     {
         $danka = Danka::find($id);
         $bouzuId = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzuId)) {
-            return view('welcome')->with('status', 'erroUnauthorized');
+            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
         } else {
             return view('dankas.edit', ['danka' => $danka]);
         }
@@ -83,7 +83,7 @@ class DankaController extends Controller
         $danka = Danka::find($dankaId);
         $bouzuId = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzuId)) {
-            return Redirect::route('welcome')->with('status', 'erroUnauthorized');
+            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
         } else {
             $danka->fill($request->validated());
             //TODO: ここで、emailとphone_numberどっちかはあるように確認
@@ -102,7 +102,7 @@ class DankaController extends Controller
         $danka = Danka::find($id);
         $bouzuId = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzuId)) {
-            return Redirect::route('welcome')->with('status', 'erroUnauthorized');
+            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
         } else {
             $danka->delete();
             return Redirect::to(route('dankas.index'));

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -71,9 +71,8 @@ class DankaController extends Controller
         $bouzu_id = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzu_id)) {
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
-        } else {
-            return view('dankas.edit', ['danka' => $danka]);
         }
+            return view('dankas.edit', ['danka' => $danka]);
     }
 
     public function update(DankaUpdateRequest $request): RedirectResponse
@@ -84,12 +83,12 @@ class DankaController extends Controller
         $bouzu_id = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzu_id)) {
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
-        } else {
-            $danka->fill($request->validated());
-            //TODO: ここで、emailとphone_numberどっちかはあるように確認
-            $danka->save();
-            return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
         }
+        $danka->fill($request->validated());
+        //TODO: ここで、emailとphone_numberどっちかはあるように確認
+        $danka->save();
+        return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
+        
     }
 
     public function destroy(Request $request): RedirectResponse
@@ -103,9 +102,8 @@ class DankaController extends Controller
         $bouzu_id = $danka->bouzu_id;
         if (!Danka::isLoginBouzu($bouzu_id)) {
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
-        } else {
-            $danka->delete();
-            return Redirect::to(route('dankas.index'));
         }
+        $danka->delete();
+        return Redirect::to(route('dankas.index'));
     }
 }

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -68,9 +68,9 @@ class DankaController extends Controller
     public function edit($id): View | RedirectResponse
     {
         $danka = Danka::find($id);
-        $bouzuId = $danka->bouzu_id;
-        if (!Danka::isLoginBouzu($bouzuId)) {
-            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
+        $bouzu_id = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzu_id)) {
+            return Redirect::route('welcome')->with('status', 'error-unauthorized');
         } else {
             return view('dankas.edit', ['danka' => $danka]);
         }
@@ -79,16 +79,16 @@ class DankaController extends Controller
     public function update(DankaUpdateRequest $request): RedirectResponse
     {
 
-        $dankaId = $request->id;
-        $danka = Danka::find($dankaId);
-        $bouzuId = $danka->bouzu_id;
-        if (!Danka::isLoginBouzu($bouzuId)) {
-            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
+        $danka_id = $request->id;
+        $danka = Danka::find($danka_id);
+        $bouzu_id = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzu_id)) {
+            return Redirect::route('welcome')->with('status', 'error-unauthorized');
         } else {
             $danka->fill($request->validated());
             //TODO: ここで、emailとphone_numberどっちかはあるように確認
             $danka->save();
-            return Redirect::route('dankas.edit', ['id' => $dankaId])->with('status', 'danka-updated');
+            return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
         }
     }
 
@@ -100,9 +100,9 @@ class DankaController extends Controller
 
         $id = $request->id;
         $danka = Danka::find($id);
-        $bouzuId = $danka->bouzu_id;
-        if (!Danka::isLoginBouzu($bouzuId)) {
-            return Redirect::route('welcome')->with('status', 'errorUnauthorized');
+        $bouzu_id = $danka->bouzu_id;
+        if (!Danka::isLoginBouzu($bouzu_id)) {
+            return Redirect::route('welcome')->with('status', 'error-unauthorized');
         } else {
             $danka->delete();
             return Redirect::to(route('dankas.index'));

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -18,12 +18,7 @@ class Danka extends Model
 
     public static function isLoginBouzu($bouzu_id) : bool
     {
-        $login_id = Auth::id(); 
-        if ($bouzu_id === $login_id) {
-            return true;
-        } else {
-            return false;
-        }
+        return $bouzu_id === Auth::id();
     }
 
     /**

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
 
 class Danka extends Model
 {
@@ -13,6 +14,16 @@ class Danka extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'bouzu_id');
+    }
+
+    public static function isLoginBouzu($bouzu_id) : bool
+    {
+        $loginId = Auth::id(); 
+        if ($bouzu_id === $loginId) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -18,8 +18,8 @@ class Danka extends Model
 
     public static function isLoginBouzu($bouzu_id) : bool
     {
-        $loginId = Auth::id(); 
-        if ($bouzu_id === $loginId) {
+        $login_id = Auth::id(); 
+        if ($bouzu_id === $login_id) {
             return true;
         } else {
             return false;

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -55,7 +55,7 @@
                     </header>
 
                     <main class="mt-6">
-                    @if (session('status') === 'erroUnauthorized')
+                    @if (session('status') === 'errorUnauthorized')
                         <p
                         x-data="{ show: true }"
                         x-show="show"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -55,7 +55,7 @@
                     </header>
 
                     <main class="mt-6">
-                    @if (session('status') === 'errorUnauthorized')
+                    @if (session('status') === 'error-unauthorized')
                         <p
                         x-data="{ show: true }"
                         x-show="show"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -55,6 +55,15 @@
                     </header>
 
                     <main class="mt-6">
+                    @if (session('status') === 'erroUnauthorized')
+                        <p
+                        x-data="{ show: true }"
+                        x-show="show"
+                        x-transition
+                        x-init="setTimeout(() => show = false, 2000)"
+                        class="text-sm text-gray-600"
+                        >error: 許可されていない挙動です</p>
+                    @endif
                         <div class="grid gap-6 lg:grid-cols-2 lg:gap-8">
                             <a
                                 href="https://laravel.com/docs"

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
-});
+})->name('welcome');
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
# 概要
- 檀家更新時と削除時に、編集対象のdankaのbouzu_idと、ログイン中のユーザーのidとの一致を検証する

# やったこと
- Dankaモデルに、id一致検証のメソッドを追加
- 以下３つのアクションでそのメソッドを使用
  - edit (編集画面表示)
  - update (更新)
  - destroy (削除)

# レビューで特に見てほしいところ
- updateとdestroyを権限のない人が試みた場合の挙動は検証できていないので、重点的に見てほしいです
- 変数名の書き方について迷いがあったので、記法が混ざってないかも見てほしいです

# 関連issue
- #21 
- #10 