### PR TITLE
檀家情報に、メールアドレスか電話番号どちらかは入っているようにする

### DIFF
--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -45,8 +45,6 @@ class DankaController extends Controller
             'note' => ['nullable', 'string'],
         ]);
 
-        //TODO: ここで、emailとphone_numberが両方nullになっていないか確認する。
-        //両方nullの場合は、どちらかは入れてもらうようメッセージを出す
         if (Danka::hasNoContactInfo($danka_info)) {
             return redirect()->back()->with('status', 'require-email-or-phone-number')->withInput();
         }
@@ -90,7 +88,6 @@ class DankaController extends Controller
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
         }
 
-        //TODO: ここで、emailとphone_numberどっちかはあるように確認
         $danka_info = $request->validated();
         if (Danka::hasNoContactInfo($danka_info)) {
             return redirect()->back()->with('status', 'require-email-or-phone-number')->withInput();

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -33,7 +33,7 @@ class DankaController extends Controller
     public function store(Request $request): RedirectResponse
     {
 
-        $request->validate([
+        $danka_info = $request->validate([
             'family_head_last_name' => ['required', 'string', 'max:255'],
             'family_head_first_name' => ['required', 'string', 'max:255'],
             'family_head_last_name_kana' => ['required', 'string', 'max:255'],
@@ -45,10 +45,13 @@ class DankaController extends Controller
             'note' => ['nullable', 'string'],
         ]);
 
-        $bouzu_id = Auth::id();
-
         //TODO: ここで、emailとphone_numberが両方nullになっていないか確認する。
         //両方nullの場合は、どちらかは入れてもらうようメッセージを出す
+        if (Danka::hasNoContactInfo($danka_info)) {
+            return redirect()->back()->with('status', 'require-email-or-phone-number')->withInput();
+        }
+
+        $bouzu_id = Auth::id();
 
         $danka = Danka::create([
             'family_head_last_name' => $request->family_head_last_name,
@@ -82,11 +85,18 @@ class DankaController extends Controller
         $danka_id = $request->id;
         $danka = Danka::find($danka_id);
         $bouzu_id = $danka->bouzu_id;
+
         if (!Danka::isLoginBouzu($bouzu_id)) {
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
         }
-        $danka->fill($request->validated());
+
         //TODO: ここで、emailとphone_numberどっちかはあるように確認
+        $danka_info = $request->validated();
+        if (Danka::hasNoContactInfo($danka_info)) {
+            return redirect()->back()->with('status', 'require-email-or-phone-number')->withInput();
+        }
+
+        $danka->fill($danka_info);
         $danka->save();
         return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
         

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -16,11 +16,24 @@ class Danka extends Model
         return $this->belongsTo(User::class, 'bouzu_id');
     }
 
+
+    /**
+     * ログイン中のユーザーに、対象の檀家の編集・削除の権限があるか確認するメソッド
+     * 
+     * @param int $bouzu_id
+     * @return bool
+     */
     public static function isLoginBouzu($bouzu_id) : bool
     {
         return $bouzu_id === Auth::id();
     }
 
+    /**
+     * メールアドレスと電話番号、両方がnullならtrueを返すメソッド
+     * 
+     * @param array $danka_info
+     * @return bool 
+     */
     public static function hasNoContactInfo($danka_info) : bool
     {
         return $danka_info['email'] === null && $danka_info['phone_number'] === null;

--- a/app/Models/Danka.php
+++ b/app/Models/Danka.php
@@ -21,6 +21,11 @@ class Danka extends Model
         return $bouzu_id === Auth::id();
     }
 
+    public static function hasNoContactInfo($danka_info) : bool
+    {
+        return $danka_info['email'] === null && $danka_info['phone_number'] === null;
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/resources/views/dankas/edit.blade.php
+++ b/resources/views/dankas/edit.blade.php
@@ -84,6 +84,13 @@
                 <x-input-error :messages="$errors->get('email_confirmation')" class="mt-2" />
             </div>
 
+            <!-- phone_number -->
+            <div class="mt-4">
+                <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
+                <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number', $danka->phone_number)" />
+                <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
+            </div>  
+
             <!-- postcode -->
             <div class="mt-4">
                 <x-input-label for="postcode" value="郵便番号" />
@@ -96,13 +103,6 @@
                 <x-input-label for="address" value="住所" />
                 <x-text-input id="address" class="block mt-1 w-full" type="text" name="address" :value="old('address', $danka->address)" />
                 <x-input-error :messages="$errors->get('address')" class="mt-2" />
-            </div>  
-
-            <!-- phone_number -->
-            <div class="mt-4">
-                <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
-                <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number', $danka->phone_number)" />
-                <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
             </div>  
             
             <!-- note -->

--- a/resources/views/dankas/edit.blade.php
+++ b/resources/views/dankas/edit.blade.php
@@ -25,8 +25,7 @@
                 x-data="{ show: true }"
                 x-show="show"
                 x-transition
-                x-init="setTimeout(() => show = false, 2000)"
-                class="text-sm text-gray-600"
+                class="text-sm text-red-500"
             >メールアドレスか電話番号のどちらかは入力してください</p>
         @endif
         
@@ -38,61 +37,77 @@
             <input type="hidden" id="id" name="id" value="{{ $danka->id }}">
 
             <!-- family_head_last_name -->
-            <div>
+            <div class="mt-4">
+            <div class="flex items-center">
                 <x-input-label for="family_head_last_name" value="代表者 姓" />
-                <x-text-input id="family_head_last_name" class="block mt-1 w-full" type="text" name="family_head_last_name" :value="old('family_head_last_name', $danka->family_head_last_name)" required autofocus />
-                <x-input-error :messages="$errors->get('family_head_last_name')" class="mt-2" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
             </div>
+            <x-text-input id="family_head_last_name" class="block mt-1 w-full" type="text" name="family_head_last_name" :value="old('family_head_last_name')" required autofocus />
+            <x-input-error :messages="$errors->get('family_head_last_name')" class="mt-2" />
+        </div>
 
-            <!-- family_head_first_name -->
-            <div class="mt-4">
+        <!-- family_head_first_name -->
+        <div class="mt-4">
+            <div class="flex items-center">
                 <x-input-label for="family_head_first_name" value="代表者 名" />
-                <x-text-input id="family_head_first_name" class="block mt-1 w-full" type="text" name="family_head_first_name" :value="old('family_head_first_name', $danka->family_head_first_name)" required />
-                <x-input-error :messages="$errors->get('family_head_first_name')" class="mt-2" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
             </div>
+            <x-text-input id="family_head_first_name" class="block mt-1 w-full" type="text" name="family_head_first_name" :value="old('family_head_first_name')" required />
+            <x-input-error :messages="$errors->get('family_head_first_name')" class="mt-2" />
+        </div>
 
-            <!-- family_head_last_name_kana -->
-            <div class="mt-4">
+        <!-- family_head_last_name_kana -->
+        <div class="mt-4">
+            <div class="flex items-center">
                 <x-input-label for="family_head_last_name_kana" value="代表者 せい" />
-                <x-text-input id="family_head_last_name_kana" class="block mt-1 w-full" type="text" name="family_head_last_name_kana" :value="old('family_head_last_name_kana', $danka->family_head_last_name_kana)" required />
-                <x-input-error :messages="$errors->get('family_head_last_name_kana')" class="mt-2" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
             </div>
+            <x-text-input id="family_head_last_name_kana" class="block mt-1 w-full" type="text" name="family_head_last_name_kana" :value="old('family_head_last_name_kana')" required />
+            <x-input-error :messages="$errors->get('family_head_last_name_kana')" class="mt-2" />
+        </div>
 
-            <!-- family_head_first_name_kana -->
-            <div class="mt-4">
+        <!-- family_head_first_name_kana -->
+        <div class="mt-4">
+            <div class="flex items-center">
                 <x-input-label for="family_head_first_name_kana" value="代表者 めい" />
-                <x-text-input id="family_head_first_name_kana" class="block mt-1 w-full" type="text" name="family_head_first_name_kana" :value="old('family_head_first_name_kana', $danka->family_head_first_name_kana)" required />
-                <x-input-error :messages="$errors->get('family_head_first_name_kana')" class="mt-2" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
             </div>
+            <x-text-input id="family_head_first_name_kana" class="block mt-1 w-full" type="text" name="family_head_first_name_kana" :value="old('family_head_first_name_kana')" required />
+            <x-input-error :messages="$errors->get('family_head_first_name_kana')" class="mt-2" />
+        </div>
 
-            <!-- email -->
-            <div class="mt-4">
-                <x-input-label for="email" value="連絡用メールアドレス" />
-                <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $danka->email)"/>
-                <x-input-error :messages="$errors->get('email')" class="mt-2" />
-            </div>        
+        <div class="mt-8">
+            <p class="text-sm ml-1">連絡が取れるようにするため、電話番号とメールアドレス、どちらかは<span class="text-red-500">必ず</span>ご登録をお願いいたします</p>
+        </div>
 
-            <!-- email_confirmation -->
-            <div class="mt-4">
-                <x-input-label for="email_confirmation" value="連絡用メールアドレス(確認用)" />
+        <!-- email -->
+        <div class="mt-4">
+            <x-input-label for="email" value="連絡用メールアドレス" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')"/>
+            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        </div>        
 
-                <x-text-input id="email_confirmation" class="block mt-1 w-full"
-                                type="email"
-                                name="email_confirmation" 
-                                :value="old('email_confirmation')"/>
+        <!-- email_confirmation -->
+        <div class="mt-4">
+            <x-input-label for="email_confirmation" value="連絡用メールアドレス(確認用)" />
 
-                <x-input-error :messages="$errors->get('email_confirmation')" class="mt-2" />
-            </div>
+            <x-text-input id="email_confirmation" class="block mt-1 w-full"
+                            type="email"
+                            name="email_confirmation" 
+                            :value="old('email_confirmation')"/>
 
-            <!-- phone_number -->
-            <div class="mt-4">
-                <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
-                <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number', $danka->phone_number)" />
-                <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
-            </div>  
+            <x-input-error :messages="$errors->get('email_confirmation')" class="mt-2" />
+        </div>
 
-            <!-- postcode -->
-            <div class="mt-4">
+        <!-- phone_number -->
+        <div class="mt-4">
+            <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
+            <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number')" />
+            <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
+        </div>  
+
+        <!-- postcode -->
+        <div class="mt-8">
                 <x-input-label for="postcode" value="郵便番号" />
                 <x-text-input id="postcode" class="block mt-1 w-full" type="tel" name="postcode" :value="old('postcode', $danka->postcode)" />
                 <x-input-error :messages="$errors->get('postcode')" class="mt-2" />

--- a/resources/views/dankas/edit.blade.php
+++ b/resources/views/dankas/edit.blade.php
@@ -11,13 +11,23 @@
         </header>
 
         @if (session('status') === 'danka-updated')
-                <p
-                    x-data="{ show: true }"
-                    x-show="show"
-                    x-transition
-                    x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm text-gray-600"
-                >更新しました</p>
+            <p
+                x-data="{ show: true }"
+                x-show="show"
+                x-transition
+                x-init="setTimeout(() => show = false, 2000)"
+                class="text-sm text-gray-600"
+            >更新しました</p>
+        @endif
+
+        @if (session('status') === 'require-email-or-phone-number')
+            <p
+                x-data="{ show: true }"
+                x-show="show"
+                x-transition
+                x-init="setTimeout(() => show = false, 2000)"
+                class="text-sm text-gray-600"
+            >メールアドレスか電話番号のどちらかは入力してください</p>
         @endif
         
         <form action="{{ route('dankas.update', ['id' => $danka->id]) }}" method="post" class="mt-6 space-y-6" >

--- a/resources/views/dankas/register.blade.php
+++ b/resources/views/dankas/register.blade.php
@@ -5,39 +5,54 @@
         x-data="{ show: true }"
         x-show="show"
         x-transition
-        x-init="setTimeout(() => show = false, 2000)"
-        class="text-sm text-gray-600"
+        class="text-sm text-red-500"
         >メールアドレスか電話番号のどちらかは入力してください</p>
     @endif
     <form method="POST" action="{{ route('dankas.register') }}">
         @csrf
 
         <!-- family_head_last_name -->
-        <div>
-            <x-input-label for="family_head_last_name" value="代表者 姓" />
+        <div class="mt-4">
+            <div class="flex items-center">
+                <x-input-label for="family_head_last_name" value="代表者 姓" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
+            </div>
             <x-text-input id="family_head_last_name" class="block mt-1 w-full" type="text" name="family_head_last_name" :value="old('family_head_last_name')" required autofocus />
             <x-input-error :messages="$errors->get('family_head_last_name')" class="mt-2" />
         </div>
 
         <!-- family_head_first_name -->
         <div class="mt-4">
-            <x-input-label for="family_head_first_name" value="代表者 名" />
+            <div class="flex items-center">
+                <x-input-label for="family_head_first_name" value="代表者 名" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
+            </div>
             <x-text-input id="family_head_first_name" class="block mt-1 w-full" type="text" name="family_head_first_name" :value="old('family_head_first_name')" required />
             <x-input-error :messages="$errors->get('family_head_first_name')" class="mt-2" />
         </div>
 
         <!-- family_head_last_name_kana -->
         <div class="mt-4">
-            <x-input-label for="family_head_last_name_kana" value="代表者 せい" />
+            <div class="flex items-center">
+                <x-input-label for="family_head_last_name_kana" value="代表者 せい" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
+            </div>
             <x-text-input id="family_head_last_name_kana" class="block mt-1 w-full" type="text" name="family_head_last_name_kana" :value="old('family_head_last_name_kana')" required />
             <x-input-error :messages="$errors->get('family_head_last_name_kana')" class="mt-2" />
         </div>
 
         <!-- family_head_first_name_kana -->
         <div class="mt-4">
-            <x-input-label for="family_head_first_name_kana" value="代表者 めい" />
+            <div class="flex items-center">
+                <x-input-label for="family_head_first_name_kana" value="代表者 めい" />
+                <span class="text-red-500 text-sm ml-1">　　必須</span>
+            </div>
             <x-text-input id="family_head_first_name_kana" class="block mt-1 w-full" type="text" name="family_head_first_name_kana" :value="old('family_head_first_name_kana')" required />
             <x-input-error :messages="$errors->get('family_head_first_name_kana')" class="mt-2" />
+        </div>
+
+        <div class="mt-8">
+            <p class="text-sm ml-1">連絡が取れるようにするため、電話番号とメールアドレス、どちらかは<span class="text-red-500">必ず</span>ご登録をお願いいたします</p>
         </div>
 
         <!-- email -->
@@ -67,7 +82,7 @@
         </div>  
 
         <!-- postcode -->
-        <div class="mt-4">
+        <div class="mt-8">
             <x-input-label for="postcode" value="郵便番号" />
             <x-text-input id="postcode" class="block mt-1 w-full" type="tel" name="postcode" :value="old('postcode')" />
             <x-input-error :messages="$errors->get('postcode')" class="mt-2" />

--- a/resources/views/dankas/register.blade.php
+++ b/resources/views/dankas/register.blade.php
@@ -59,6 +59,13 @@
             <x-input-error :messages="$errors->get('email_confirmation')" class="mt-2" />
         </div>
 
+        <!-- phone_number -->
+        <div class="mt-4">
+            <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
+            <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number')" />
+            <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
+        </div>  
+
         <!-- postcode -->
         <div class="mt-4">
             <x-input-label for="postcode" value="郵便番号" />
@@ -71,13 +78,6 @@
             <x-input-label for="address" value="住所" />
             <x-text-input id="address" class="block mt-1 w-full" type="text" name="address" :value="old('address')" />
             <x-input-error :messages="$errors->get('address')" class="mt-2" />
-        </div>  
-
-        <!-- phone_number -->
-        <div class="mt-4">
-            <x-input-label for="phone_number" value="電話番号 (市外局番からお入れください)" />
-            <x-text-input id="phone_number" class="block mt-1 w-full" type="tel" name="phone_number" :value="old('phone_number')" />
-            <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
         </div>  
         
         <!-- note -->

--- a/resources/views/dankas/register.blade.php
+++ b/resources/views/dankas/register.blade.php
@@ -1,4 +1,14 @@
 <x-guest-layout>
+
+    @if (session('status') === 'require-email-or-phone-number')
+        <p
+        x-data="{ show: true }"
+        x-show="show"
+        x-transition
+        x-init="setTimeout(() => show = false, 2000)"
+        class="text-sm text-gray-600"
+        >メールアドレスか電話番号のどちらかは入力してください</p>
+    @endif
     <form method="POST" action="{{ route('dankas.register') }}">
         @csrf
 


### PR DESCRIPTION
# 概要
- 檀家登録時と檀家編集時に、メールアドレスと電話番号のどちらかは入力されているようにする

# やったこと
## モデル
- Dankaモデルに、メールアドレスと電話番号が両方nullの場合にtrueを返すメソッドを追加
## コントローラ
- storeアクションとeditアクションで、モデルに追加した上記メソッドを使用。両方nullの場合はエラーメッセージを表示する
## ビュー
- 檀家登録画面と編集画面にエラーメッセージを表示
## その他
- 檀家登録フォームと編集フォームで電話番号の表示位置を変更

# 特に見てほしいところ
- 動きはするのですが、適した形での実装かどうかは自信がないです

# 関連issue
- #22 