### PR TITLE
檀家更新後のリダイレクト先と通知内容を変更

### DIFF
--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -95,7 +95,9 @@ class DankaController extends Controller
 
         $danka->fill($danka_info);
         $danka->save();
-        return Redirect::route('dankas.index')->with('status', 'danka-updated');
+        return Redirect::route('dankas.index')->with([
+        'status' => 'danka-updated',
+        'danka' => $danka ]);
         
     }
 

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -95,7 +95,7 @@ class DankaController extends Controller
 
         $danka->fill($danka_info);
         $danka->save();
-        return Redirect::route('dankas.edit', ['id' => $danka_id])->with('status', 'danka-updated');
+        return Redirect::route('dankas.index')->with('status', 'danka-updated');
         
     }
 

--- a/resources/views/dankas/edit.blade.php
+++ b/resources/views/dankas/edit.blade.php
@@ -10,16 +10,6 @@
             </p>
         </header>
 
-        @if (session('status') === 'danka-updated')
-            <p
-                x-data="{ show: true }"
-                x-show="show"
-                x-transition
-                x-init="setTimeout(() => show = false, 2000)"
-                class="text-sm text-gray-600"
-            >更新しました</p>
-        @endif
-
         @if (session('status') === 'require-email-or-phone-number')
             <p
                 x-data="{ show: true }"

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -16,7 +16,7 @@
                         x-transition
                         x-init="setTimeout(() => show = false, 2000)"
                         class="text-sm text-gray-600"
-                    >更新しました</p>
+                    >{{ session('danka')->family_head_last_name }}{{ session('danka')->family_head_first_name}}さんの情報を更新しました</p>
                 @endif
                     <table border="1">
                         <tr>

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -9,6 +9,15 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
+                @if (session('status') === 'danka-updated')
+                    <p
+                        x-data="{ show: true }"
+                        x-show="show"
+                        x-transition
+                        x-init="setTimeout(() => show = false, 2000)"
+                        class="text-sm text-gray-600"
+                    >更新しました</p>
+                @endif
                     <table border="1">
                         <tr>
                             <th>氏名</th>


### PR DESCRIPTION
# 概要
- 檀家更新後のリダイレクト先を、檀家編集画面から檀家一覧画面に変更
- 更新後の成功通知に更新した檀家の代表者姓名を表示

# やったこと
## コントローラ
- updateアクションのリダイレクト先を檀家一覧画面(`danka.index`)に変更
- その際withメソッドで檀家の情報をセッションに入れるように
## ビュー
- 更新成功通知を`danka.edit`から`danka.index`に移動
- セッションから檀家情報を受け取り、代表者姓名を表示

# 関連issue
#26 