### PR TITLE
檀家一覧画面に、ソート機能とページネーションを追加

### DIFF
--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -14,18 +14,19 @@ use Illuminate\View\View;
 
 class DankaController extends Controller
 {
+    private const ITEMS_PER_PAGE_OPTIONS = [
+        0 => 10,
+        1 => 25,
+        2 => 50,
+        3 => 100,
+    ];
+
     //檀家一覧
     public function index(Request $request)
     {
-        $pag_list = [
-            0 => 10,
-            1 => 25,
-            2 => 50,
-            3 => 100,
-        ];
         $disp_list = $request->disp_list;
         if (empty($disp_list)) {
-            $disp_list = 10;
+            $disp_list = self::ITEMS_PER_PAGE_OPTIONS[0];
         }
 
         $sort_list = $request->sort_list;
@@ -58,7 +59,14 @@ class DankaController extends Controller
         $dankas = $dankas->paginate($disp_list);
 
 
-        return view('dankas.index', ['pag_list' => $pag_list, 'disp_list' => $disp_list, 'dankas' => $dankas]);
+        return view(
+            'dankas.index',
+            [
+                'ITEMS_PER_PAGE_OPTIONS' => self::ITEMS_PER_PAGE_OPTIONS,
+                'disp_list' => $disp_list,
+                'dankas' => $dankas
+            ]
+        );
     }
 
     //檀家登録画面の表示

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -15,12 +15,23 @@ use Illuminate\View\View;
 class DankaController extends Controller
 {
     //檀家一覧
-    public function index()
+    public function index(Request $request)
     {
-        $bouzu_id = Auth::id();
-        $dankas = Danka::where('bouzu_id', $bouzu_id)->orderBy('created_at', 'desc')->paginate(10);
+        $pag_list = [
+            0 => 10,
+            1 => 25,
+            2 => 50,
+            3 => 100,
+        ];
+        $disp_list = $request->disp_list;
+        if (empty($disp_list)) {
+            $disp_list = 0;
+        }
 
-        return view('dankas.index', ['dankas' => $dankas]);
+        $bouzu_id = Auth::id();
+        $dankas = Danka::where('bouzu_id', $bouzu_id)->orderBy('created_at', 'desc')->paginate($disp_list);
+
+        return view('dankas.index', ['pag_list' => $pag_list, 'disp_list' => $disp_list, 'dankas' => $dankas]);
     }
 
     //檀家登録画面の表示

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -25,11 +25,34 @@ class DankaController extends Controller
         ];
         $disp_list = $request->disp_list;
         if (empty($disp_list)) {
-            $disp_list = 0;
+            $disp_list = 10;
+        }
+
+        $sort_list = $request->sort_list;
+        switch ($sort_list) {
+            case 'newest':
+                $sort = 'id';
+                $order = 'desc';
+                break;
+            case 'oldest':
+                $sort = 'id';
+                $order = 'asc';
+                break;
+            case 'syllabary':
+                $sort = 'family_head_last_name_kana';
+                $order = 'asc';
+                break;
+            default:
+                $sort = 'created_at';
+                $order = 'desc';
+                break;
         }
 
         $bouzu_id = Auth::id();
-        $dankas = Danka::where('bouzu_id', $bouzu_id)->orderBy('created_at', 'desc')->paginate($disp_list);
+        $dankas = Danka::where('bouzu_id', $bouzu_id)
+            ->orderBy($sort, $order)
+            ->orderBy('family_head_first_name_kana', 'asc')
+            ->paginate($disp_list);
 
         return view('dankas.index', ['pag_list' => $pag_list, 'disp_list' => $disp_list, 'dankas' => $dankas]);
     }

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -24,8 +24,9 @@ class DankaController extends Controller
     //檀家一覧
     public function index(Request $request)
     {
-        $disp_list = $request->disp_list;
-        if (empty($disp_list)) {
+        if ($request->filled('disp_list')) {
+            $disp_list = $request->disp_list;
+        } else {
             $disp_list = self::ITEMS_PER_PAGE_OPTIONS[0];
         }
 

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -31,11 +31,11 @@ class DankaController extends Controller
         $sort_list = $request->sort_list;
         switch ($sort_list) {
             case 'newest':
-                $sort = 'id';
+                $sort = 'created_at';
                 $order = 'desc';
                 break;
             case 'oldest':
-                $sort = 'id';
+                $sort = 'created_at';
                 $order = 'asc';
                 break;
             case 'syllabary':
@@ -49,10 +49,14 @@ class DankaController extends Controller
         }
 
         $bouzu_id = Auth::id();
+
         $dankas = Danka::where('bouzu_id', $bouzu_id)
-            ->orderBy($sort, $order)
-            ->orderBy('family_head_first_name_kana', 'asc')
-            ->paginate($disp_list);
+            ->orderBy($sort, $order);
+        if ($sort_list === 'syllabary') {
+            $dankas = $dankas->orderBy('family_head_first_name_kana', 'asc');
+        }
+        $dankas = $dankas->paginate($disp_list);
+
 
         return view('dankas.index', ['pag_list' => $pag_list, 'disp_list' => $disp_list, 'dankas' => $dankas]);
     }

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -98,7 +98,7 @@ class DankaController extends Controller
 
         $bouzu_id = Auth::id();
 
-        $danka = Danka::create([
+        Danka::create([
             'family_head_last_name' => $request->family_head_last_name,
             'family_head_first_name' => $request->family_head_first_name,
             'family_head_last_name_kana' => $request->family_head_last_name_kana,

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -62,7 +62,7 @@ class DankaController extends Controller
         return view(
             'dankas.index',
             [
-                'ITEMS_PER_PAGE_OPTIONS' => self::ITEMS_PER_PAGE_OPTIONS,
+                'items_per_page_options' => self::ITEMS_PER_PAGE_OPTIONS,
                 'disp_list' => $disp_list,
                 'dankas' => $dankas
             ]

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -18,7 +18,7 @@ class DankaController extends Controller
     public function index()
     {
         $bouzu_id = Auth::id();
-        $dankas = Danka::where('bouzu_id', $bouzu_id)->get()->sortByDesc('created_at');
+        $dankas = Danka::where('bouzu_id', $bouzu_id)->orderBy('created_at', 'desc')->paginate(10);
 
         return view('dankas.index', ['dankas' => $dankas]);
     }
@@ -38,7 +38,7 @@ class DankaController extends Controller
             'family_head_first_name' => ['required', 'string', 'max:255'],
             'family_head_last_name_kana' => ['required', 'string', 'max:255'],
             'family_head_first_name_kana' => ['required', 'string', 'max:255'],
-            'email' => ['nullable', 'confirmed', 'string', 'lowercase', 'email', 'max:255', 'unique:'.Danka::class],
+            'email' => ['nullable', 'confirmed', 'string', 'lowercase', 'email', 'max:255', 'unique:' . Danka::class],
             'postcode' => ['nullable', 'string', 'max:255'],
             'address' => ['nullable', 'string', 'max:255'],
             'phone_number' => ['nullable', 'string', 'max:255'],
@@ -74,7 +74,7 @@ class DankaController extends Controller
         if (!Danka::isLoginBouzu($bouzu_id)) {
             return Redirect::route('welcome')->with('status', 'error-unauthorized');
         }
-            return view('dankas.edit', ['danka' => $danka]);
+        return view('dankas.edit', ['danka' => $danka]);
     }
 
     public function update(DankaUpdateRequest $request): RedirectResponse
@@ -96,9 +96,9 @@ class DankaController extends Controller
         $danka->fill($danka_info);
         $danka->save();
         return Redirect::route('dankas.index')->with([
-        'status' => 'danka-updated',
-        'danka' => $danka ]);
-        
+            'status' => 'danka-updated',
+            'danka' => $danka
+        ]);
     }
 
     public function destroy(Request $request): RedirectResponse

--- a/app/Http/Controllers/DankaController.php
+++ b/app/Http/Controllers/DankaController.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rules;
+
+use Illuminate\Validation\Rule;
+
 use Illuminate\View\View;
 
 class DankaController extends Controller
@@ -24,11 +27,11 @@ class DankaController extends Controller
     //檀家一覧
     public function index(Request $request)
     {
-        if ($request->filled('disp_list')) {
-            $disp_list = $request->disp_list;
-        } else {
-            $disp_list = self::ITEMS_PER_PAGE_OPTIONS[0];
-        }
+
+        $validate = $request->validate([
+            'disp_list' => Rule::in(self::ITEMS_PER_PAGE_OPTIONS)
+        ]);
+        $disp_list = intval($validate['disp_list']);
 
         $sort_list = $request->sort_list;
         switch ($sort_list) {

--- a/config/app.php
+++ b/config/app.php
@@ -82,7 +82,7 @@ return [
 
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
 
-    'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
+    'faker_locale' => env('APP_FAKER_LOCALE', 'ja_JP'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/factories/DankaFactory.php
+++ b/database/factories/DankaFactory.php
@@ -22,6 +22,7 @@ class DankaFactory extends Factory
     public function definition(): array
     {
         $jp_faker = FakerFactory::create("ja_JP");
+        $address = $jp_faker->prefecture() . $jp_faker->city() . $jp_faker->streetAddress() . $jp_faker->secondaryAddress();
         return [
             //　'カラム名' => '設定したい値',
             'family_head_last_name' => $jp_faker->lastName(),
@@ -30,9 +31,9 @@ class DankaFactory extends Factory
             'family_head_first_name_kana' => $jp_faker->firstKanaName(),
             'email' => $jp_faker->unique()->safeEmail(),
             'postcode' => $jp_faker->postcode(),
-            'address' => $jp_faker->address(),
-            'phone_number' => $jp_faker->phoneNumber(),
-            'note' => $jp_faker->realText(),
+            'address' => $address,
+            'phone_number' => preg_replace('/[-]/', '', $jp_faker->phoneNumber()),
+            'note' => $jp_faker->realText(50),
             'bouzu_id' => 1
         ];
     }

--- a/database/factories/DankaFactory.php
+++ b/database/factories/DankaFactory.php
@@ -21,19 +21,18 @@ class DankaFactory extends Factory
 
     public function definition(): array
     {
-        $jp_faker = FakerFactory::create("ja_JP");
-        $address = $jp_faker->prefecture() . $jp_faker->city() . $jp_faker->streetAddress() . $jp_faker->secondaryAddress();
+        $address = fake()->prefecture() . fake()->city() . fake()->streetAddress() . fake()->secondaryAddress();
         return [
             //　'カラム名' => '設定したい値',
-            'family_head_last_name' => $jp_faker->lastName(),
-            'family_head_first_name' => $jp_faker->firstName(),
-            'family_head_last_name_kana' => $jp_faker->lastKanaName(),
-            'family_head_first_name_kana' => $jp_faker->firstKanaName(),
-            'email' => $jp_faker->unique()->safeEmail(),
-            'postcode' => $jp_faker->postcode(),
+            'family_head_last_name' => fake()->lastName(),
+            'family_head_first_name' => fake()->firstName(),
+            'family_head_last_name_kana' => fake()->lastKanaName(),
+            'family_head_first_name_kana' => fake()->firstKanaName(),
+            'email' => fake()->unique()->safeEmail(),
+            'postcode' => fake()->postcode(),
             'address' => $address,
-            'phone_number' => preg_replace('/[-]/', '', $jp_faker->phoneNumber()),
-            'note' => $jp_faker->realText(50),
+            'phone_number' => preg_replace('/[-]/', '', fake()->phoneNumber()),
+            'note' => fake()->realText(50),
             'bouzu_id' => 1
         ];
     }

--- a/database/factories/DankaFactory.php
+++ b/database/factories/DankaFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Danka;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Faker\Factory as FakerFactory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Danka>
+ */
+class DankaFactory extends Factory
+{
+    protected $model = Danka::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+
+    public function definition(): array
+    {
+        $jp_faker = FakerFactory::create("ja_JP");
+        return [
+            //　'カラム名' => '設定したい値',
+            'family_head_last_name' => $jp_faker->lastName(),
+            'family_head_first_name' => $jp_faker->firstName(),
+            'family_head_last_name_kana' => $jp_faker->lastKanaName(),
+            'family_head_first_name_kana' => $jp_faker->firstKanaName(),
+            'email' => $jp_faker->unique()->safeEmail(),
+            'postcode' => $jp_faker->postcode(),
+            'address' => $jp_faker->address(),
+            'phone_number' => $jp_faker->phoneNumber(),
+            'note' => $jp_faker->realText(),
+            'bouzu_id' => 1
+        ];
+    }
+}

--- a/database/seeders/DankasTableSeeder.php
+++ b/database/seeders/DankasTableSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\Danka;
+use Carbon\Carbon;
 
 class DankasTableSeeder extends Seeder
 {
@@ -13,6 +14,11 @@ class DankasTableSeeder extends Seeder
      */
     public function run(): void
     {
-        Danka::factory()->count(100)->create();
+        $now = Carbon::now();
+        Danka::factory()->count(100)->create()
+            ->each(function ($danka, $index) use ($now) {
+                $danka->created_at = $now->addSeconds($index);
+                $danka->save();
+            });
     }
 }

--- a/database/seeders/DankasTableSeeder.php
+++ b/database/seeders/DankasTableSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Danka;
+
+class DankasTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Danka::factory()->count(100)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-        //\App\Models\Danka::truncate();
+        \App\Models\Danka::truncate();
         //DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         //\App\Models\User::truncate();
         //DB::statement('SET FOREIGN_KEY_CHECKS=1;');

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,10 +14,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(DankasTableSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-        $this->call(DankasTableSeeder::class);
+        \App\Models\Danka::truncate();
+        //\App\Models\User::truncate();
+        // $this->call(DankasTableSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
@@ -14,8 +15,10 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-        \App\Models\Danka::truncate();
-        //\App\Models\User::truncate();
+        //\App\Models\Danka::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        \App\Models\User::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
         // $this->call(DankasTableSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,9 +16,9 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
         //\App\Models\Danka::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-        \App\Models\User::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        // $this->call(DankasTableSeeder::class);
+        //DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        //\App\Models\User::truncate();
+        //DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        $this->call(DankasTableSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-        \App\Models\Danka::truncate();
+        //\App\Models\Danka::truncate();
         //DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         //\App\Models\User::truncate();
         //DB::statement('SET FOREIGN_KEY_CHECKS=1;');

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -10,9 +10,9 @@
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
                     <form action="{{ route('dankas.index') }}" method="get" class="mb-4">
-                        <select name="disp_list" id="disp_list" value="{{ old('disp_list') }}" onchange="submit();">
+                        <select name="disp_list" id="disp_list" value="" onchange="submit();">
                             @foreach($pag_list as $key => $val)
-                            @if ($val === $disp_list)
+                            @if ( request('disp_list') == $val)
                             <option value="{{ $val }}" selected>{{ $val }}</option>
                             @else
                             <option value="{{ $val }}">{{ $val }}</option>
@@ -20,6 +20,11 @@
                             @endforeach
                         </select>
                         件ずつ表示
+                        <select name="sort_list" id="sort_list" value="" onchange="submit();">
+                            <option value="newest" @if( request('sort_list')==='newest' ) selected @endif>登録の新しい順</option>
+                            <option value="oldest" @if( request('sort_list')==='oldest' ) selected @endif>登録の古い順</option>
+                            <option value="syllabary" @if( request('sort_list')==='syllabary' ) selected @endif>五十音順</option>
+                        </select>
                     </form>
                     @if (session('status') === 'danka-updated')
                     <p

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -9,16 +9,15 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
-                @if (session('status') === 'danka-updated')
+                    @if (session('status') === 'danka-updated')
                     <p
                         x-data="{ show: true }"
                         x-show="show"
                         x-transition
                         x-init="setTimeout(() => show = false, 2000)"
-                        class="text-sm text-gray-600"
-                    >{{ session('danka')->family_head_last_name }}{{ session('danka')->family_head_first_name}}さんの情報を更新しました</p>
-                @endif
-                    <table border="1">
+                        class="text-sm text-gray-600">{{ session('danka')->family_head_last_name }}{{ session('danka')->family_head_first_name}}さんの情報を更新しました</p>
+                    @endif
+                    <table border="1" class="mb-4">
                         <tr>
                             <th>氏名</th>
                             <th>メールアドレス</th>
@@ -39,6 +38,7 @@
                         </tr>
                         @endforeach
                     </table>
+                    {{ $dankas->links() }}
                 </div>
             </div>
         </div>

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -11,7 +11,7 @@
                 <div class="p-6 text-gray-900">
                     <form action="{{ route('dankas.index') }}" method="get" class="mb-4">
                         <select name="disp_list" id="disp_list" value="" onchange="submit();">
-                            @foreach($pag_list as $key => $val)
+                            @foreach($ITEMS_PER_PAGE_OPTIONS as $key => $val)
                             @if ( request('disp_list') == $val)
                             <option value="{{ $val }}" selected>{{ $val }}</option>
                             @else

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -9,6 +9,18 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
+                    <form action="{{ route('dankas.index') }}" method="get" class="mb-4">
+                        <select name="disp_list" id="disp_list" value="{{ old('disp_list') }}" onchange="submit();">
+                            @foreach($pag_list as $key => $val)
+                            @if ($val === $disp_list)
+                            <option value="{{ $val }}" selected>{{ $val }}</option>
+                            @else
+                            <option value="{{ $val }}">{{ $val }}</option>
+                            @endif
+                            @endforeach
+                        </select>
+                        件ずつ表示
+                    </form>
                     @if (session('status') === 'danka-updated')
                     <p
                         x-data="{ show: true }"

--- a/resources/views/dankas/index.blade.php
+++ b/resources/views/dankas/index.blade.php
@@ -11,7 +11,7 @@
                 <div class="p-6 text-gray-900">
                     <form action="{{ route('dankas.index') }}" method="get" class="mb-4">
                         <select name="disp_list" id="disp_list" value="" onchange="submit();">
-                            @foreach($ITEMS_PER_PAGE_OPTIONS as $key => $val)
+                            @foreach($items_per_page_options as $key => $val)
                             @if ( request('disp_list') == $val)
                             <option value="{{ $val }}" selected>{{ $val }}</option>
                             @else

--- a/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-5.blade.php
@@ -1,0 +1,88 @@
+@if ($paginator->hasPages())
+    <nav class="d-flex justify-items-center justify-content-between">
+        <div class="d-flex justify-content-between flex-fill d-sm-none">
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </div>
+
+        <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
+            <div>
+                <p class="small text-muted">
+                    {!! __('Showing') !!}
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
+                    {!! __('of') !!}
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <ul class="pagination">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                            <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                        </li>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                @else
+                                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                        </li>
+                    @else
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                            <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                        </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li>
+                    <a href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="disabled" aria-disabled="true"><span>{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="active" aria-current="page"><span>{{ $page }}</span></li>
+                        @else
+                            <li><a href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li>
+                    <a href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/semantic-ui.blade.php
+++ b/resources/views/vendor/pagination/semantic-ui.blade.php
@@ -1,0 +1,36 @@
+@if ($paginator->hasPages())
+    <div class="ui pagination menu" role="navigation">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @else
+            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @endif
+
+        {{-- Pagination Elements --}}
+        @foreach ($elements as $element)
+            {{-- "Three Dots" Separator --}}
+            @if (is_string($element))
+                <a class="icon item disabled" aria-disabled="true">{{ $element }}</a>
+            @endif
+
+            {{-- Array Of Links --}}
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                    @else
+                        <a class="item" href="{{ $url }}">{{ $page }}</a>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @else
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @endif
+    </div>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
@@ -1,0 +1,27 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.previous')</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.next')</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
@@ -1,0 +1,29 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation">
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.previous') !!}</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">{!! __('pagination.next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.next') !!}</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-default.blade.php
+++ b/resources/views/vendor/pagination/simple-default.blade.php
@@ -1,0 +1,19 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.previous')</span></li>
+            @else
+                <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a></li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a></li>
+            @else
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.next')</span></li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-tailwind.blade.php
+++ b/resources/views/vendor/pagination/simple-tailwind.blade.php
@@ -1,0 +1,25 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.previous') !!}
+            </span>
+        @else
+            <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.previous') !!}
+            </a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.next') !!}
+            </a>
+        @else
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.next') !!}
+            </span>
+        @endif
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -1,0 +1,106 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+        <div class="flex justify-between flex-1 sm:hidden">
+            @if ($paginator->onFirstPage())
+                <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                    {!! __('pagination.previous') !!}
+                </span>
+            @else
+                <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                    {!! __('pagination.previous') !!}
+                </a>
+            @endif
+
+            @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                    {!! __('pagination.next') !!}
+                </a>
+            @else
+                <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                    {!! __('pagination.next') !!}
+                </span>
+            @endif
+        </div>
+
+        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+            <div>
+                <p class="text-sm text-gray-700 leading-5 dark:text-gray-400">
+                    {!! __('Showing') !!}
+                    @if ($paginator->firstItem())
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        {!! __('to') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                    @else
+                        {{ $paginator->count() }}
+                    @endif
+                    {!! __('of') !!}
+                    <span class="font-medium">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                            <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @else
+                        <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.previous') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <span aria-disabled="true">
+                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
+                            </span>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page">
+                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
+                                    </span>
+                                @else
+                                    <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.next') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @else
+                        <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                            <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @endif
+                </span>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -1,106 +1,105 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
-        <div class="flex justify-between flex-1 sm:hidden">
-            @if ($paginator->onFirstPage())
-                <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
-                    {!! __('pagination.previous') !!}
-                </span>
-            @else
-                <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
-                    {!! __('pagination.previous') !!}
-                </a>
-            @endif
+<nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+    <div class="flex justify-between flex-1 sm:hidden">
+        @if ($paginator->onFirstPage())
+        <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+            {!! __('pagination.previous') !!}
+        </span>
+        @else
+        <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+            {!! __('pagination.previous') !!}
+        </a>
+        @endif
 
-            @if ($paginator->hasMorePages())
-                <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
-                    {!! __('pagination.next') !!}
-                </a>
-            @else
-                <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
-                    {!! __('pagination.next') !!}
-                </span>
-            @endif
+        @if ($paginator->hasMorePages())
+        <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+            {!! __('pagination.next') !!}
+        </a>
+        @else
+        <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+            {!! __('pagination.next') !!}
+        </span>
+        @endif
+    </div>
+
+    <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <div>
+            <p class="text-sm text-gray-700 leading-5 dark:text-gray-400">
+                @if ($paginator->firstItem())
+                <span class="font-medium">{{ $paginator->total() }}</span>
+                件中
+                <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                件〜
+                <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                @else
+                {{ $paginator->count() }}
+                @endif
+                件を表示
+            </p>
         </div>
 
-        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-            <div>
-                <p class="text-sm text-gray-700 leading-5 dark:text-gray-400">
-                    {!! __('Showing') !!}
-                    @if ($paginator->firstItem())
-                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        {!! __('to') !!}
-                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                    @else
-                        {{ $paginator->count() }}
-                    @endif
-                    {!! __('of') !!}
-                    <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('results') !!}
-                </p>
-            </div>
-
-            <div>
-                <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
-                    {{-- Previous Page Link --}}
-                    @if ($paginator->onFirstPage())
-                        <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
-                            <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
-                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
-                                </svg>
-                            </span>
-                        </span>
-                    @else
-                        <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.previous') }}">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
-                            </svg>
-                        </a>
-                    @endif
-
-                    {{-- Pagination Elements --}}
-                    @foreach ($elements as $element)
-                        {{-- "Three Dots" Separator --}}
-                        @if (is_string($element))
-                            <span aria-disabled="true">
-                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
-                            </span>
-                        @endif
-
-                        {{-- Array Of Links --}}
-                        @if (is_array($element))
-                            @foreach ($element as $page => $url)
-                                @if ($page == $paginator->currentPage())
-                                    <span aria-current="page">
-                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
-                                    </span>
-                                @else
-                                    <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
-                                        {{ $page }}
-                                    </a>
-                                @endif
-                            @endforeach
-                        @endif
-                    @endforeach
-
-                    {{-- Next Page Link --}}
-                    @if ($paginator->hasMorePages())
-                        <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.next') }}">
-                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
-                            </svg>
-                        </a>
-                    @else
-                        <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
-                            <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
-                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
-                                </svg>
-                            </span>
-                        </span>
-                    @endif
+        <div>
+            <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                    <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
                 </span>
-            </div>
+                @else
+                <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.previous') }}">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                    </svg>
+                </a>
+                @endif
+
+                {{-- Pagination Elements --}}
+                @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                <span aria-disabled="true">
+                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
+                </span>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                @foreach ($element as $page => $url)
+                @if ($page == $paginator->currentPage())
+                <span aria-current="page">
+                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-red-200 border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
+                </span>
+                @else
+                <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                    {{ $page }}
+                </a>
+                @endif
+                @endforeach
+                @endif
+                @endforeach
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.next') }}">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                    </svg>
+                </a>
+                @else
+                <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                    <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
+                </span>
+                @endif
+            </span>
         </div>
-    </nav>
+    </div>
+</nav>
 @endif

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -71,7 +71,7 @@
                 @foreach ($element as $page => $url)
                 @if ($page == $paginator->currentPage())
                 <span aria-current="page">
-                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-red-200 border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
+                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-gray-200 border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
                 </span>
                 @else
                 <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -29,7 +29,7 @@
                 <span class="font-medium">{{ $paginator->total() }}</span>
                 件中
                 <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                件〜
+                〜
                 <span class="font-medium">{{ $paginator->lastItem() }}</span>
                 @else
                 {{ $paginator->count() }}


### PR DESCRIPTION
# 概要
- 檀家一覧画面に、ソート機能とページネーションを追加

# やったこと
## テストデータの挿入
- `DankaFactory.php`を作成し、その中でfakerを使用
- `DankasTableSeeder.php`と`DatabaseSeeder.php`の編集
## ページネーションの実装
- 文章を日本語化
  - 「100件中1〜10件を表示」
- 選択中のページだけ色を変更
- 表示件数の選択機能を追加
  - デフォルトは10件
## ソート機能の実装
- 以下3パターン選択できるように
  - 登録の新しい順
  - 登録の古い順
  - 五十音順

# レビューで特に見てほしいところ
- 意図しない挙動が起こっていないか

# その他
- `sail artisan db:seed`でテストデータを追加してください

# 関連Issue
#30 